### PR TITLE
Add full support for SHA256 and SHA512 digests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - 1.9.3
   - 2.1.6
   - 2.2.2
+  - 2.3
+  - 2.4
   - jruby
 before_install:
   - gem update --system

--- a/apache_authtkt.gemspec
+++ b/apache_authtkt.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'apache_authtkt'
-  s.version     = '2.0.0'
+  s.version     = '2.1.0'
   s.license     = 'Apache v2'
   s.date        = '2015-07-29'
   s.rubyforge_project = 'nowarning'

--- a/lib/apache_authtkt.rb
+++ b/lib/apache_authtkt.rb
@@ -130,18 +130,13 @@ class ApacheAuthTkt
 
    end
 
-   def digest_klass(algo)
-     Object.const_get("Digest::#{algo.upcase}")
-   end
-
    def get_digest(ts, ipaddr, user, tokens, data)
       ipts = [ip2long(ipaddr), ts].pack("NN")
       digest0 = nil
       digest  = nil
       raw     = ipts + @secret + user + "\0" + tokens + "\0" + data
-      digester = digest_klass(@digest_type)
-      digest0 = digester.hexdigest(raw)
-      digest  = digester.hexdigest(digest0 + @secret)
+      digest0 = digest_klass.hexdigest(raw)
+      digest  = digest_klass.hexdigest(digest0 + @secret)
       return digest
    end
 
@@ -207,4 +202,9 @@ class ApacheAuthTkt
       !(parsed[:ts] + @lifetime >= Time.now.to_i)
    end
 
+   private
+
+   def digest_klass
+     Digest.const_get(@digest_type.upcase)
+   end
 end

--- a/lib/apache_authtkt.rb
+++ b/lib/apache_authtkt.rb
@@ -20,9 +20,8 @@ require 'rubygems'
 require 'base64'
 require 'digest'
 
-class InvalidDigestTypeError < StandardError; end
-
 class ApacheAuthTkt
+  class InvalidDigestTypeError < StandardError; end
 
    attr_accessor :secret
    attr_accessor :ipaddr

--- a/lib/apache_authtkt.rb
+++ b/lib/apache_authtkt.rb
@@ -20,6 +20,8 @@ require 'rubygems'
 require 'base64'
 require 'digest'
 
+class InvalidDigestTypeError < StandardError; end
+
 class ApacheAuthTkt
 
    attr_accessor :secret
@@ -63,6 +65,8 @@ class ApacheAuthTkt
       else
          @digest_type = 'md5'
       end
+
+      raise(InvalidDigestTypeError, @digest_type) unless DIGEST_LENGTHS[@digest_type.downcase]
 
       if (args.has_key? :base64encode)
          @base64encode = args[:base64encode]

--- a/lib/apache_authtkt.rb
+++ b/lib/apache_authtkt.rb
@@ -140,12 +140,8 @@ class ApacheAuthTkt
       digest  = nil
       raw     = ipts + @secret + user + "\0" + tokens + "\0" + data
       digester = digest_klass(@digest_type)
-      begin
-        digest0 = digester.hexdigest(raw)
-        digest  = digester.hexdigest(digest0 + @secret)
-      rescue
-         raise "unsupported digest type: " + @digest_type
-      end
+      digest0 = digester.hexdigest(raw)
+      digest  = digester.hexdigest(digest0 + @secret)
       return digest
    end
 

--- a/spec/lib/apache_authtkt_spec.rb
+++ b/spec/lib/apache_authtkt_spec.rb
@@ -26,13 +26,15 @@ describe ApacheAuthTkt do
   end
 
   it 'should round-trip' do
-    atkt = ApacheAuthTkt.new(secret: 'fee-fi-fo-fum')
-    tkt = atkt.create_ticket(ts: 1000)
-    parsed = atkt.validate_ticket(tkt)
-    expect(parsed[:user]).to eql 'guest'
-    expect(parsed[:ts]).to eql 1000
-    expect(parsed[:tokens]).to eql ''
-    expect(parsed[:data]).to eql ''
+    ['Md5', 'sHA256', 'SHa512'].each do |digest_type|
+      atkt = ApacheAuthTkt.new(secret: 'fee-fi-fo-fum', digest_type: digest_type)
+      tkt = atkt.create_ticket(ts: 1000)
+      parsed = atkt.validate_ticket(tkt)
+      expect(parsed[:user]).to eql 'guest'
+      expect(parsed[:ts]).to eql 1000
+      expect(parsed[:tokens]).to eql ''
+      expect(parsed[:data]).to eql ''
+    end
   end
 
   # json payload to test quotes bug

--- a/spec/lib/apache_authtkt_spec.rb
+++ b/spec/lib/apache_authtkt_spec.rb
@@ -37,6 +37,13 @@ describe ApacheAuthTkt do
         expect(parsed[:data]).to eql ''
       end
     end
+
+    it 'dies on invalid digest type' do
+      atkt = ApacheAuthTkt.new(secret: 'fee-fi-fo-fum', digest_type: 'nope')
+      expect {
+        tkt = atkt.create_ticket(ts: 1000)
+      }.to raise_error(LoadError)
+    end
   end
 
   # json payload to test quotes bug

--- a/spec/lib/apache_authtkt_spec.rb
+++ b/spec/lib/apache_authtkt_spec.rb
@@ -41,7 +41,7 @@ describe ApacheAuthTkt do
     it 'dies on invalid digest type' do
       expect {
         atkt = ApacheAuthTkt.new(secret: 'fee-fi-fo-fum', digest_type: 'nope')
-      }.to raise_error(InvalidDigestTypeError)
+      }.to raise_error(ApacheAuthTkt::InvalidDigestTypeError)
     end
   end
 

--- a/spec/lib/apache_authtkt_spec.rb
+++ b/spec/lib/apache_authtkt_spec.rb
@@ -25,15 +25,17 @@ describe ApacheAuthTkt do
     expect(tkt).to eql 'ZWRmMzllMmM2NWFmNjljOWZlY2U1OTJmODE0OTQ2M2U0NzI1NThiMDE2YmFjMzRiMjMwM2UzM2FmNDM0MzYzYzAwMDAwM2U4Z3Vlc3QhIQ=='
   end
 
-  it 'should round-trip' do
+  describe 'digest types' do
     ['Md5', 'sHA256', 'SHa512'].each do |digest_type|
-      atkt = ApacheAuthTkt.new(secret: 'fee-fi-fo-fum', digest_type: digest_type)
-      tkt = atkt.create_ticket(ts: 1000)
-      parsed = atkt.validate_ticket(tkt)
-      expect(parsed[:user]).to eql 'guest'
-      expect(parsed[:ts]).to eql 1000
-      expect(parsed[:tokens]).to eql ''
-      expect(parsed[:data]).to eql ''
+      it "should round-trip #{digest_type}" do
+        atkt = ApacheAuthTkt.new(secret: 'fee-fi-fo-fum', digest_type: digest_type)
+        tkt = atkt.create_ticket(ts: 1000)
+        parsed = atkt.validate_ticket(tkt)
+        expect(parsed[:user]).to eql 'guest'
+        expect(parsed[:ts]).to eql 1000
+        expect(parsed[:tokens]).to eql ''
+        expect(parsed[:data]).to eql ''
+      end
     end
   end
 

--- a/spec/lib/apache_authtkt_spec.rb
+++ b/spec/lib/apache_authtkt_spec.rb
@@ -39,10 +39,9 @@ describe ApacheAuthTkt do
     end
 
     it 'dies on invalid digest type' do
-      atkt = ApacheAuthTkt.new(secret: 'fee-fi-fo-fum', digest_type: 'nope')
       expect {
-        tkt = atkt.create_ticket(ts: 1000)
-      }.to raise_error(LoadError)
+        atkt = ApacheAuthTkt.new(secret: 'fee-fi-fo-fum', digest_type: 'nope')
+      }.to raise_error(InvalidDigestTypeError)
     end
   end
 


### PR DESCRIPTION
mod_auth_tkt for Apache 2.4 supports both SHA256 and SHA512.

Also fixes `validate_ticket` when using non-md5 digest type, and normalizes case to support `SHA256` or `sha256`.